### PR TITLE
FIX : missing GETPOST check parameters (none)

### DIFF
--- a/admin/attachments_setup.php
+++ b/admin/attachments_setup.php
@@ -51,7 +51,7 @@ $action = GETPOST('action', 'alpha');
 if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
-	if (dolibarr_set_const($db, $code, GETPOST($code), 'chaine', 0, '', $conf->entity) > 0)
+	if (dolibarr_set_const($db, $code, GETPOST($code, 'none'), 'chaine', 0, '', $conf->entity) > 0)
 	{
 		header("Location: ".$_SERVER["PHP_SELF"]);
 		exit;
@@ -61,7 +61,7 @@ if (preg_match('/set_(.*)/',$action,$reg))
 		dol_print_error($db);
 	}
 }
-	
+
 if (preg_match('/del_(.*)/',$action,$reg))
 {
 	$code=$reg[1];

--- a/class/actions_attachments.class.php
+++ b/class/actions_attachments.class.php
@@ -266,7 +266,7 @@ class ActionsAttachments
             if ($action === 'attachments_send')
             {
                 dol_include_once('attachments/lib/attachments.lib.php');
-                $this->formconfirm = getFormConfirmAttachments($this, $this->TFilePathByTitleKey, GETPOST('trackid'));
+                $this->formconfirm = getFormConfirmAttachments($this, $this->TFilePathByTitleKey, GETPOST('trackid', 'none'));
                 $action = 'presend';
                 $_POST['addfile'] = ''; // Permet de bi-passer un setEventMessage de Dolibarr
             }
@@ -290,7 +290,7 @@ class ActionsAttachments
 
                 include_once DOL_DOCUMENT_ROOT.'/core/class/html.formmail.class.php';
                 $formmail = new FormMail($this->db);
-                $formmail->trackid = GETPOST('trackid');
+                $formmail->trackid = GETPOST('trackid', 'none');
 
                 // Je ne peux pas me baser sur le chemin complet car une fois joint au mail, les chemins pointe vers le dossier "/temp" du user
                 $TSelectedFileName = array();


### PR DESCRIPTION
# FIX

A partir de la v12 le paramètre check de la fonction GETPOST est alphanohtml par défaut ce qui fait que tous nos inputs ayant une balise html sont vidés.

Modification (et typage) de tous les paramètres check manquants.