### PR TITLE
get product folder for PRODUCT_USE_OLD_PATH_FOR_PHOTO

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## Version 1.0.2 [ 16/12/2020 ]
+## Version 1.0 [ 16/12/2020 ]
+
+- FIX : attachment should manage PRODUCT_USE_OLD_PATH_FOR_PHOTO *23/04/2021* - 1.0.3
 
 ### Fix 
 

--- a/class/actions_attachments.class.php
+++ b/class/actions_attachments.class.php
@@ -209,6 +209,12 @@ class ActionsAttachments
                     if (!empty($sub_element_to_use)) $filedir = $conf->{$element_to_use}->{$sub_element_to_use}->dir_output . $subdir . '/' . $linkObjRef;
                     else $filedir = $conf->{$element_to_use}->dir_output . $subdir . '/' . $linkObjRef;
 
+                    if ($element == 'product' && !empty($conf->global->PRODUCT_USE_OLD_PATH_FOR_PHOTO))
+					{
+						$pdir = get_exdir($linkedObject->id, 2, 0, 0, $linkedObject, 'product') . $linkedObject->id ."/photos/";
+						$filedir = $conf->product->dir_output.'/'.$pdir;
+					}
+
                     $file_list=dol_dir_list($filedir, 'files', 0, '', '(\.meta|_preview.*.*\.png)$', 'date', SORT_DESC);
 
                     if (!empty($file_list))
@@ -286,7 +292,6 @@ class ActionsAttachments
                         $TAttachments[$v] = $v;
                     }
                 }
-
 
                 include_once DOL_DOCUMENT_ROOT.'/core/class/html.formmail.class.php';
                 $formmail = new FormMail($this->db);

--- a/core/modules/modAttachments.class.php
+++ b/core/modules/modAttachments.class.php
@@ -46,7 +46,7 @@ class modAttachments extends DolibarrModules
 
 		$this->editor_name = 'ATM-Consulting';
 		$this->editor_url = 'https://www.atm-consulting.fr';
-		
+
 		// Id for module (must be unique).
 		// Use here a free id (See in Home -> System information -> Dolibarr for list of used modules id).
 		$this->numero = 104902; // 104000 to 104999 for ATM CONSULTING
@@ -61,7 +61,7 @@ class modAttachments extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module Attachments";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.0.2';
+		$this->version = '1.0.3';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)
@@ -70,7 +70,7 @@ class modAttachments extends DolibarrModules
 		// If file is in theme/yourtheme/img directory under name object_pictovalue.png, use this->picto='pictovalue'
 		// If file is in module/img directory under name object_pictovalue.png, use this->picto='pictovalue@module'
 		$this->picto='attachments@attachments';
-		
+
 		// Defined all module parts (triggers, login, substitutions, menus, css, etc...)
 		// for default path (eg: /attachments/core/xxxxx) (0=disable, 1=enable)
 		// for specific path of parts (eg: /attachments/core/modules/barcode)
@@ -194,7 +194,7 @@ class modAttachments extends DolibarrModules
 		$this->rights[$r][4] = 'read';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$this->rights[$r][5] = '';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$r++;
-		
+
 		$this->rights[$r][0] = $this->numero . $r;	// Permission id (must not be already used)
 		$this->rights[$r][1] = 'attachments_write';	// Permission label
 		$this->rights[$r][3] = 1; 					// Permission by default for new user (0/1)
@@ -245,9 +245,9 @@ class modAttachments extends DolibarrModules
 		//							'target'=>'',
 		//							'user'=>2);				                // 0=Menu for internal users, 1=external users, 2=both
 		// $r++;
-		
+
 /*
-		$this->menu[$r]=array(	
+		$this->menu[$r]=array(
 			'fk_menu'=>0,			                // Put 0 if this is a top menu
 			'type'=>'top',			                // This is a Top menu entry
 			'titre'=>$langs->trans('TopMenuAttachments'),
@@ -278,7 +278,7 @@ class modAttachments extends DolibarrModules
 			'user'=>0
 		);
 		$r++;
-		
+
 		$this->menu[$r]=array(
 			'fk_menu'=>'fk_mainmenu=attachments,fk_leftmenu=attachments_left',		    // Use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
 			'type'=>'left',			                // This is a Left menu entry
@@ -294,7 +294,7 @@ class modAttachments extends DolibarrModules
 			'user'=>0
 		);				                // 0=Menu for internal users, 1=external users, 2=both
 		$r++;
-		
+
 
 		$this->menu[$r]=array(
 			'fk_menu'=>'fk_mainmenu=attachments,fk_leftmenu=attachments_left',		    // Use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
@@ -312,7 +312,7 @@ class modAttachments extends DolibarrModules
 		);				                // 0=Menu for internal users, 1=external users, 2=both
 		$r++;
 */
-		
+
 		// Exports
 		$r=1;
 
@@ -342,7 +342,7 @@ class modAttachments extends DolibarrModules
 	function init($options='')
 	{
 		$sql = array();
-		
+
 		define('INC_FROM_DOLIBARR',true);
 
 		require dol_buildpath('/attachments/script/create-maj-base.php');


### PR DESCRIPTION
When the PRODUCT_USE_OLD_PATH_FOR_PHOTO is not empty, the folder structure for product documents is different.
So this is impossible to find product linked files