### PR TITLE
FIX - 1.0.7 - error message in v14 due to formconfirm behavior

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ## Version 1.0 [ 16/12/2020 ]
+- FIX : error message in v14 due to formconfirm change *25/11/2021* - 1.0.7
 - FIX : warning (foreach over non-arrays) *20/10/2021* - 1.0.6
 - FIX : v14 compatibility (only change is in module descriptor) *29/06/2021* - 1.0.5
 - FIX : FIX clear attached files in mail using template *08/06/2021* - 1.0.5

--- a/core/modules/modAttachments.class.php
+++ b/core/modules/modAttachments.class.php
@@ -61,7 +61,7 @@ class modAttachments extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module Attachments";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.0.6';
+		$this->version = '1.0.7';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/lib/attachments.lib.php
+++ b/lib/attachments.lib.php
@@ -143,7 +143,7 @@ function getFormConfirmAttachments($actionattachments, $TFilePathByTitleKey, $tr
                         ' . str_repeat('&nbsp;', 8) . '<input id="' . $id . '" name="' . $id . '" type="checkbox" ' . $checked . ' value="' . $info['fullname_md5'] . '" class="pull-right" />
                         <label for="' . $id . '">' . $info['name'] . '</label>
                     </div>';
-				    $formquestion[] = array('name' => 'TAttachments_' . $info['fullname_md5']);
+				    $formquestion[] = array('name' => 'TAttachments_' . $info['fullname_md5'], 'type' => 'text');
 			    }
 		    }
 		    $html .= '</dd>';


### PR DESCRIPTION
this is a quickfix, a full rewrite would take too long but there is obviously a bigger problem with `$formquestion`