### PR TITLE
Add project attachment type. If an object is linked to a project, check (and add) if project has attached files.

### DIFF
--- a/langs/en_US/attachments.lang
+++ b/langs/en_US/attachments.lang
@@ -27,6 +27,9 @@ AttachmentsTitleFactureFournisseur=Vendor invoice
 AttachmentsTitleFicheInter=Intervention
 AttachmentsSociete=Company
 AttachmentsTitleEcm=Documents (EDM)
+AttachmentsTitleTask=Tasks
+AttachmentsTitleProject=Project
+AttachmentsShipping=Shipping
 
 AttachmentsFiltered=Elements corresponding to your search term
 AttachmentsSelectedOnTotalAvailable=Number of selected elements on total available

--- a/langs/fr_FR/attachments.lang
+++ b/langs/fr_FR/attachments.lang
@@ -28,6 +28,7 @@ AttachmentsTitleFicheInter=Intervention
 AttachmentsSociete=Société
 AttachmentsTitleEcm=Documents (GED)
 AttachmentsTitleTask=Tâches
+AttachmentsTitleProject=Projet
 AttachmentsShipping=Expedition
 
 AttachmentsFiltered=Nombre d'éléments correspondant à votre recherche

--- a/lib/attachments.lib.php
+++ b/lib/attachments.lib.php
@@ -129,6 +129,7 @@ function getFormConfirmAttachments($actionattachments, $TFilePathByTitleKey, $tr
 
 	    $html .= '<dd class="panel">';
 	    if (is_array($TFilePathByRef) && count($TFilePathByRef) > 0) {
+
 		    foreach ($TFilePathByRef as $ref => $file_info) {
 			    $class = $object->ref === $ref ? 'currentobject' : '';
 			    $html .= '
@@ -143,11 +144,14 @@ function getFormConfirmAttachments($actionattachments, $TFilePathByTitleKey, $tr
                         ' . str_repeat('&nbsp;', 8) . '<input id="' . $id . '" name="' . $id . '" type="checkbox" ' . $checked . ' value="' . $info['fullname_md5'] . '" class="pull-right" />
                         <label for="' . $id . '">' . $info['name'] . '</label>
                     </div>';
-				    $formquestion[] = array('name' => 'TAttachments_' . $info['fullname_md5'], 'type' => 'hidden');
 			    }
+
 		    }
+
 		    $html .= '</dd>';
+
 	    }
+
     }
     $html.= '</dl>';
 
@@ -242,8 +246,8 @@ function getFormConfirmAttachments($actionattachments, $TFilePathByTitleKey, $tr
         , '<i>'.$langs->trans('ConfirmCancelAttachmentsBody').'</i>'
         , 'confirm_attachments_send'
         , $formquestion
+        , 'yes'
         , 0
-        , 1
         , 'auto'
         , '800'
     );


### PR DESCRIPTION
Add project attachment type. If object is linked to a project, check (and add) if project has attached files.
Also remove hidden fields (in confirmation form) which conflict with files checkbox values, and switch form to non-ajax.