### PR TITLE
Update actions_attachments.class.php

### DIFF
--- a/class/actions_attachments.class.php
+++ b/class/actions_attachments.class.php
@@ -474,7 +474,7 @@ class ActionsAttachments extends \attachments\RetroCompatCommonHookActions
 
 				if (is_dir($fullname))
 				{
-					$this->nyandog($key, $fullname, $file);
+					$this->nyandog($key, $fullname.'/', $file);
 				}
 				elseif (is_file($fullname))
 				{


### PR DESCRIPTION
Si on choisi un dossier de la GED à proposer dans la sélection des fichiers à joindre, la récursivité (gestion des sous-répertoire) ne fonctionne pas !